### PR TITLE
Add types for calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,17 +293,17 @@ easyinvoice.createInvoice(data, function (result) {
 
 ## Return values
 
-|<b>Key</b> | Value | Data Type |
-|---|---|---|
-| <b>result.pdf</b>             | <b>The PDF file as base64 string</b>                                 | <b>String</b> |
+|<b>Key</b> | Value                                                  | Data Type |
+|---|--------------------------------------------------------|---|
+| <b>result.pdf</b>             | <b>The PDF file as base64 string</b>                   | <b>String</b> |
 | result.calculations.products | Array of objects reflecting the products used in creation | Array |
-| result.calculations.products[key].subtotal | Rounded price without tax per product | Number |
-| result.calculations.products[key].tax | Rounded tax per product | Number |
-| result.calculations.products[key].total | Rounded price including tax per product | Number |
-| result.calculations.tax | Array of objects containing total calculated tax per unique tax rate | Array |
-| result.calculations.tax[rate] | Total tax for all products with same tax rate  | Number |
-| result.calculations.subtotal | Rounded price without tax for all products | Number |
-| result.calculations.total | Rounded price without tax for all products | Number |
+| result.calculations.products[key].subtotal | Rounded price without tax per product                  | Number |
+| result.calculations.products[key].tax | Rounded tax per product                                | Number |
+| result.calculations.products[key].total | Rounded price including tax per product                | Number |
+| result.calculations.tax | Object containing total calculated tax per unique tax rate  | Array |
+| result.calculations.tax[rate] | Total tax for all products with same tax rate          | Number |
+| result.calculations.subtotal | Rounded price without tax for all products             | Number |
+| result.calculations.total | Rounded price with tax for all products                | Number |
 
 <br/>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,31 @@ export type InvoiceData = {
     bottomNotice?: string
 }
 
+export type InvoiceCalculations = {
+    /** Array of objects reflecting the products used in creation	 */
+    products: ProductCalculations[]
+    /** Object containing total calculated tax per unique tax rate */
+    tax: TaxCalculations
+    /** Rounded price without tax for all products	 */
+    subtotal: number
+    /** Rounded price with tax for all products	 */
+    total: number
+}
+
+type ProductCalculations = {
+    subtotal: number
+    tax: number
+    total: number
+}
+
+type TaxCalculations = {
+    /** The key is a unique tax rate and the value is the total calculated tax for the rate */
+    [key: number]: number
+}
+
 type CreateInvoiceResult = {
     pdf: string // Base64
+    calculations: InvoiceCalculations
 }
 
 declare module 'easyinvoice' {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,16 +31,16 @@ export type InvoiceImages = {
 }
 
 export type InvoiceTranslations = {
-        invoice?: string,
-        number?: string,
-        date?: string,
-        "due-date"?: string,
-        subtotal?: string,
-        products?: string,
-        quantity?: string,
-        price?: string,
-        "product-total"?: string,
-        total?: string
+    invoice?: string,
+    number?: string,
+    date?: string,
+    "due-date"?: string,
+    subtotal?: string,
+    products?: string,
+    quantity?: string,
+    price?: string,
+    "product-total"?: string,
+    total?: string
 }
 
 export type InvoiceInformation = {


### PR DESCRIPTION
I did the following changes:

- [x] Added types for invoice calculations
- [x] Removed unnecessary indentation in types file
- [x] Readme incorrectly stated that `calculations.total` is the rounded price **without** tax. I fixed it to say that it's **with** tax
- [x] Readme said that `calculations.tax` was an array of objects. I fixed it to say that it's an object